### PR TITLE
update opentbs plugin to 1.9.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ What is special to OpenTBS:
 ## Versions included
 TinyButStrong - 3.10.1
 
-OpenTBS - 1.9.7
+OpenTBS - 1.9.10
 
 ## Requirements
 


### PR DESCRIPTION
# Changelog from previous plugin version
## version 1.9.10, on 2017-07-05

Bug fixes
* DOCM, PPTM and XSLM documents (that is documents with macros) are merged correctly but Ms Office display an error message when the file is dowloaded using $TBS->Show(OPENTBS_DOWNLOAD,...).
## version 1.9.9, on 2017-05-28

Bug fixes
* XLSX sheet containing an empty and unformatted row may produce in some circumstances a corrupted result when merged.
## version 1.9.8, on 2016-12-27

New features
* New command OPENTBS_MAKE_OPTIMIZED_TEMPLATE

Bug fixes
* Processed templates are not marked as prepared.